### PR TITLE
style: update with black v22.1.0

### DIFF
--- a/bio/biobambam2/bamsormadup/wrapper.py
+++ b/bio/biobambam2/bamsormadup/wrapper.py
@@ -34,7 +34,7 @@ if metrics:
 with tempfile.TemporaryDirectory() as tmpdir:
     # This folder must not exist; it is created by BamSorMaDup
     tmpdir_bamsormadup = Path(tmpdir) / "bamsormadup_{:06d}".format(
-        random.randrange(10 ** 6)
+        random.randrange(10**6)
     )
 
     shell(

--- a/bio/gatk/applybqsrspark/wrapper.py
+++ b/bio/gatk/applybqsrspark/wrapper.py
@@ -21,7 +21,7 @@ log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 with tempfile.TemporaryDirectory() as tmpdir:
     # This folder must not exist; it is created by GATK
-    tmpdir_shards = Path(tmpdir) / "shards_{:06d}".format(random.randrange(10 ** 6))
+    tmpdir_shards = Path(tmpdir) / "shards_{:06d}".format(random.randrange(10**6))
 
     shell(
         "gatk --java-options '{java_opts}' ApplyBQSRSpark"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,12 @@ sys.path.insert(0, os.path.abspath("."))
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.intersphinx", "sphinx.ext.todo", "generate_docs", "sphinx_copybutton"]
+extensions = [
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.todo",
+    "generate_docs",
+    "sphinx_copybutton",
+]
 
 # Snakemake theme (made by SciAni).
 html_css_files = ["theme.css"]

--- a/test.py
+++ b/test.py
@@ -929,10 +929,7 @@ def test_bedtools_slop():
 
 @skip_if_not_modified
 def test_bgzip():
-    run(
-        "bio/bgzip",
-        ["snakemake", "--cores", "1", "test.vcf.gz", "--use-conda", "-F"]
-    )
+    run("bio/bgzip", ["snakemake", "--cores", "1", "test.vcf.gz", "--use-conda", "-F"])
 
 
 @skip_if_not_modified
@@ -2860,7 +2857,10 @@ def test_delly():
 
 @skip_if_not_modified
 def test_manta():
-    run("bio/manta", ["snakemake", "--cores", "2", "results/out.bcf", "--use-conda", "-F"])
+    run(
+        "bio/manta",
+        ["snakemake", "--cores", "2", "results/out.bcf", "--use-conda", "-F"],
+    )
 
 
 @skip_if_not_modified


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->
I hope this addresses the CI problem over at the snakemake-wrappers repo.

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [ ] there is a test case which covers any introduced changes,
* [ ] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [ ] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [ ] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [ ] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [ ] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [ ] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [ ] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [ ] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [ ] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [ ] `Snakefile`s pass the linting (`snakemake --lint`),
* [ ] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [ ] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
